### PR TITLE
klteactivexx: Add L-based Radio and QC Framework files to blob list

### DIFF
--- a/device-proprietary-files.txt
+++ b/device-proprietary-files.txt
@@ -1,2 +1,27 @@
+# Qualcomm Framework - Pinned to G900FXXS1BPCL_G900FOXA1BOJ1_BTU
+lib/libmdmdetect.so:vendor/lib/libmdmdetect.so|9c19d5aacc094597c166529386f83ac721ac1979
+vendor/lib/libconfigdb.so|a7eedfbb0ffa070c9239f0d293262e268342da1d
+vendor/lib/libdiag.so|2dd30d2de57567aa4575f98e4679cdbd625bbbe6
+vendor/lib/libdsutils.so|99fac25d6a10ea89a7f66cfc7c3a36478a178568
+vendor/lib/libidl.so|9b871bda84a1204b35b5a93311d666aa36a7f8b8
+vendor/lib/libnetmgr.so|fc8dcd60b4fd28518e03949842dd6b496712c2d1
+vendor/lib/libqcci_legacy.so|5f0f25a72677d0b3183031490e45b6de26735327
+vendor/lib/libqmi.so|d120b126ba94cb2d4164243ef7a8516168b6fedf
+vendor/lib/libqmi_cci.so|b94c84c54183e538a7802ca531da7cf2b8176614
+vendor/lib/libqmi_client_qmux.so|79cb7b305bd9f87c581f26c805f4ca2bbdf3a069
+vendor/lib/libqmi_common_so.so|6c70d0c23898f4d5aa5a962736a06aa3d21e7aa6
+vendor/lib/libqmi_csi.so|dee249a1f0fff082b5e5547cfab103ac10ab55e2
+vendor/lib/libqmi_encdec.so|82e39ae7e4bb8651d06fdae99fc38e3fb390b62d
+vendor/lib/libqmiservices.so|0b90d67d7ec0b0bc3de2b5ccc3afcda13bd5ffd8
+
+# Radio - Pinned to G900FXXS1BPCL_G900FOXA1BOJ1_BTU
+bin/efsks:vendor/bin/efsks|2c366ac7ab878068c77e5598c411a48cf47b056a
+bin/ks:vendor/bin/ks|949406ae5d1b74034b3828af1905a181e4b69961
+bin/qcks:vendor/bin/qcks|9026c84f32e1ee5121024c72b878c09dfde95e5b
+bin/qmuxd:vendor/bin/qmuxd|e257d63996812e2eb23810bda59913f558ee03d2
+bin/rfs_access:vendor/bin/rfs_access|49a8516ed01b609a9e5079d8135b75db5b024236
+bin/rmt_storage:vendor/bin/rmt_storage|000ddcabfc9416e9a27ba6d04860cc14b6803cdd
+vendor/lib/libril-qcril-hook-oem.so|6a73ed46f4fbcb283eea5fb44b24a7d14522bfe5
+
 # Radio - pinned to G870FXXU1BQE1_G870FOXX1BQE1_XEO
 lib/libsec-ril.so:vendor/lib/libsec-ril.so|6686590c3cf1a5caa1c9976f5c6bbcdffe588656


### PR DESCRIPTION
* This device cannot use the M-based ones from -common

Change-Id: I2dfc24b57278f375fbc5d46acdb8f1b671137245